### PR TITLE
Ignore nodes that return no facts

### DIFF
--- a/puppetdb.rb
+++ b/puppetdb.rb
@@ -67,8 +67,10 @@ def get_node_info(nodes)
   nodes.each do |node|
     facts = []
     get_facts(node).each { |x| facts.push(x) }
-    meta[facts[0]['value']] = { 'ansible_host' => facts[1]['value'] }
-    hosts.push(facts[0]['value'])
+    if !facts.to_a.empty?
+      meta[facts[0]['value']] = { 'ansible_host' => facts[1]['value'] }
+      hosts.push(facts[0]['value'])
+    end
     ## 'hack' to get around doing proper threading/batching
     ## curl gives errors w/out
     sleep(0.1)


### PR DESCRIPTION
This fixes an issue I ran into today where the inventory was broken because a certain node returned literally nothing from the facts endpoint of puppetdb

The response looked like this:

```
$ curl -X GET 'http://puppetdb/pdb/query/v4/facts' --data-urlencode 'query=["~", "certname", "0000-fff-abc-123-123"]' --silent
[]%
```

