### PR TITLE
Refactor how information about nodes is retrieved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'redis'
 
 ## because fedora/rhel
 install_if -> { RUBY_PLATFORM =~ /linux/ } do
-  gem "json"
+  gem 'json'
 end
 
 group :test do


### PR DESCRIPTION
Instead of getting the list of nodes and then making 1 request per node to get the ipaddress and fqdn facts, just make one request to get ipaddress for every node and one request to get fqdn for every node and then merge the resulting responses.

Runtime for --list (not using redis) before this change:
```
real	14m34.385s
user	2m31.647s
sys	0m3.934s
```

Runtime for --list (not using redis) after this change:
```
real	0m1.479s
user	0m0.696s
sys	0m0.188s
```